### PR TITLE
Add Microsoft Entra ID auth plugin

### DIFF
--- a/packages/plugins/@nocobase/plugin-auth-azure-ad/README.md
+++ b/packages/plugins/@nocobase/plugin-auth-azure-ad/README.md
@@ -1,0 +1,26 @@
+# Microsoft Entra ID Authentication
+
+This plugin enables authentication using Microsoft Entra ID (Azure Active Directory) and provides an action to synchronise users from Microsoft Graph.
+
+## Features
+
+- Sign in with the OAuth 2.0 authorization code from Microsoft Entra ID.
+- Automatically create or update users in NocoBase using Microsoft Graph profile data.
+- Synchronise all users from Microsoft Graph to the local database via the `azureUsers:sync` action.
+
+## Usage
+
+Configure an authenticator of type `azure-ad` with the following options:
+
+```
+{
+  "tenantId": "<tenant-id>",
+  "clientId": "<application-client-id>",
+  "clientSecret": "<client-secret>",
+  "redirectUri": "<redirect-uri>"
+}
+```
+
+Then call the authentication API with the authorization `code` returned by Microsoft Entra ID.
+
+The `azureUsers:sync` resource action can be used to fetch users from Microsoft Graph and store them in the local `users` collection.

--- a/packages/plugins/@nocobase/plugin-auth-azure-ad/package.json
+++ b/packages/plugins/@nocobase/plugin-auth-azure-ad/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@nocobase/plugin-auth-azure-ad",
+  "version": "1.8.1",
+  "main": "./dist/server/index.js",
+  "displayName": "Auth: Microsoft Entra ID",
+  "displayName.zh-CN": "认证：Microsoft Entra ID",
+  "description": "Authenticate users using Microsoft Entra ID (Azure AD) and sync users via Microsoft Graph.",
+  "description.zh-CN": "通过 Microsoft Entra ID (Azure AD) 认证用户，并通过 Microsoft Graph 同步用户。",
+  "devDependencies": {
+    "@azure/msal-node": "^3.5.0"
+  },
+  "peerDependencies": {
+    "@nocobase/actions": "1.x",
+    "@nocobase/auth": "1.x",
+    "@nocobase/client": "1.x",
+    "@nocobase/database": "1.x",
+    "@nocobase/plugin-auth": "1.x",
+    "@nocobase/server": "1.x",
+    "@nocobase/test": "1.x"
+  },
+  "keywords": [
+    "Authentication",
+    "AzureAD"
+  ]
+}

--- a/packages/plugins/@nocobase/plugin-auth-azure-ad/src/index.ts
+++ b/packages/plugins/@nocobase/plugin-auth-azure-ad/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export * from './server';
+export { default } from './server';

--- a/packages/plugins/@nocobase/plugin-auth-azure-ad/src/server/azuread-auth.ts
+++ b/packages/plugins/@nocobase/plugin-auth-azure-ad/src/server/azuread-auth.ts
@@ -1,0 +1,90 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { ConfidentialClientApplication, Configuration } from '@azure/msal-node';
+import { AuthConfig, BaseAuth } from '@nocobase/auth';
+import { Model } from '@nocobase/database';
+import { AuthModel } from '@nocobase/plugin-auth';
+
+export interface AzureADOptions {
+  tenantId: string;
+  clientId: string;
+  clientSecret: string;
+  redirectUri: string;
+}
+
+export class AzureADAuth extends BaseAuth {
+  private client: ConfidentialClientApplication;
+  private options: AzureADOptions;
+
+  constructor(config: AuthConfig) {
+    const { ctx } = config;
+    const options = ctx?.action?.params?.values?.options || {};
+    super({ ...config, userCollection: ctx.db.getCollection('users') });
+    this.options = options as AzureADOptions;
+    const authority = `https://login.microsoftonline.com/${this.options.tenantId}`;
+    const msalConfig: Configuration = {
+      auth: {
+        clientId: this.options.clientId,
+        authority,
+        clientSecret: this.options.clientSecret,
+      },
+    };
+    this.client = new ConfidentialClientApplication(msalConfig);
+  }
+
+  async validate() {
+    const ctx = this.ctx;
+    const { code } = ctx.action.params.values || {};
+    if (!code) {
+      ctx.throw(400, 'Missing code');
+    }
+    const token = await this.client.acquireTokenByAuthorizationCode({
+      code,
+      redirectUri: this.options.redirectUri,
+      scopes: ['https://graph.microsoft.com/.default'],
+    });
+    const res = await fetch('https://graph.microsoft.com/v1.0/me', {
+      headers: { Authorization: `Bearer ${token.accessToken}` },
+    });
+    if (!res.ok) {
+      ctx.throw(res.status, await res.text());
+    }
+    const profile = (await res.json()) as { id: string; userPrincipalName: string; displayName: string };
+    const authenticator = this.authenticator as AuthModel;
+    let user = await authenticator.findUser(profile.id);
+    if (!user) {
+      user = await authenticator.findOrCreateUser(profile.id, {
+        nickname: profile.displayName,
+        email: profile.userPrincipalName,
+      });
+    }
+    return user as Model;
+  }
+
+  async syncUsers() {
+    const token = await this.client.acquireTokenByClientCredential({ scopes: ['https://graph.microsoft.com/.default'] });
+    let url = 'https://graph.microsoft.com/v1.0/users';
+    const authenticator = this.authenticator as AuthModel;
+    while (url) {
+      const res = await fetch(url, { headers: { Authorization: `Bearer ${token.accessToken}` } });
+      if (!res.ok) {
+        throw new Error(await res.text());
+      }
+      const data = await res.json();
+      for (const u of data.value) {
+        await authenticator.findOrCreateUser(u.id, {
+          nickname: u.displayName,
+          email: u.mail || u.userPrincipalName,
+        });
+      }
+      url = data['@odata.nextLink'];
+    }
+  }
+}

--- a/packages/plugins/@nocobase/plugin-auth-azure-ad/src/server/index.ts
+++ b/packages/plugins/@nocobase/plugin-auth-azure-ad/src/server/index.ts
@@ -1,0 +1,11 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+export { AzureADAuth } from './azuread-auth';
+export { default } from './plugin';

--- a/packages/plugins/@nocobase/plugin-auth-azure-ad/src/server/plugin.ts
+++ b/packages/plugins/@nocobase/plugin-auth-azure-ad/src/server/plugin.ts
@@ -1,0 +1,40 @@
+/**
+ * This file is part of the NocoBase (R) project.
+ * Copyright (c) 2020-2024 NocoBase Co., Ltd.
+ * Authors: NocoBase Team.
+ *
+ * This project is dual-licensed under AGPL-3.0 and NocoBase Commercial License.
+ * For more information, please refer to: https://www.nocobase.com/agreement.
+ */
+
+import { InstallOptions, Plugin } from '@nocobase/server';
+import { tval } from '@nocobase/utils';
+import { AzureADAuth } from './azuread-auth';
+
+export const authType = 'azure-ad';
+export const namespace = 'auth-azure-ad';
+
+export class PluginAuthAzureADServer extends Plugin {
+  async load() {
+    this.app.authManager.registerTypes(authType, {
+      auth: AzureADAuth,
+      title: tval('Microsoft Entra ID', { ns: namespace }),
+    });
+
+    this.app.resource({
+      name: 'azureUsers',
+      actions: {
+        async sync(ctx) {
+          const auth = await this.app.authManager.get(authType, ctx);
+          await auth.syncUsers();
+          ctx.body = { success: true };
+        },
+      },
+    });
+    this.app.acl.allow('azureUsers', 'sync');
+  }
+
+  async install(options?: InstallOptions) {}
+}
+
+export default PluginAuthAzureADServer;


### PR DESCRIPTION
## Summary
- add new plugin `plugin-auth-azure-ad`
- implement AzureADAuth for OAuth sign in and user sync
- document how to use the plugin

## Testing
- `yarn lint` *(fails: package not in lockfile)*
- `yarn install` *(fails due to missing peer deps)*

------
https://chatgpt.com/codex/tasks/task_e_687bca0b87bc832189086b34d7e00ea6